### PR TITLE
Update webhook key names

### DIFF
--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -30,7 +30,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\register_webhook_endpoint' );
  * The payload should be delivered via an HTTP POST request, with the following structure:
  *
  * {
- *   id: XXX,
+ *   identifier: XXX,
  *   project: 'pXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
  *   document: 'dXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX'
  * }
@@ -38,7 +38,7 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\register_webhook_endpoint' );
  * @param WP_REST_Request $request The WP REST API request object.
  */
 function handle_webhook( WP_REST_Request $request ) {
-	$user_id  = $request->get_param( 'id' );
+	$user_id  = $request->get_param( 'identifier' );
 	$project  = $request->get_param( 'project' );
 	$document = $request->get_param( 'document' );
 

--- a/tests/PHPUnit/WebhookTest.php
+++ b/tests/PHPUnit/WebhookTest.php
@@ -41,7 +41,7 @@ class WebhookTest extends \Airstory\TestCase {
 		$request  = Mockery::mock( 'WP_REST_Request' )->makePartial();
 		$request->shouldReceive( 'get_param' )
 			->once()
-			->with( 'id' )
+			->with( 'identifier' )
 			->andReturn( 5 );
 		$request->shouldReceive( 'get_param' )
 			->once()
@@ -93,7 +93,7 @@ class WebhookTest extends \Airstory\TestCase {
 		$request = Mockery::mock( 'WP_REST_Request' )->makePartial();
 		$request->shouldReceive( 'get_param' )
 			->once()
-			->with( 'id' )
+			->with( 'identifier' )
 			->andReturn( 5 );
 		$request->shouldReceive( 'get_param' )
 			->once()
@@ -127,7 +127,7 @@ class WebhookTest extends \Airstory\TestCase {
 		$project  = 'pXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
 		$document = 'dXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
 		$request  = Mockery::mock( 'WP_REST_Request' )->makePartial();
-		$request->shouldReceive( 'get_param' )->with( 'id' )->andReturn( 5 );
+		$request->shouldReceive( 'get_param' )->with( 'identifier' )->andReturn( 5 );
 		$request->shouldReceive( 'get_param' )->with( 'project' )->andReturn( $project );
 		$request->shouldReceive( 'get_param' )->with( 'document' )->andReturn( $document );
 		$wp_error = Mockery::mock( 'WP_Error' );


### PR DESCRIPTION
The incoming webhook request uses keys "project", "document", and "identifier" (not "id").