### PR TITLE
Draft ordering

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -28,6 +28,8 @@ function get_current_draft( $project_id, $document_id ) {
 		'update_term_meta_cache' => false,
 		'fields'                 => 'ids',
 		'posts_per_page'         => 1,
+		'orderby'                => 'date',
+		'order'                  => 'ASC',
 		'meta_query'             => array(
 			array(
 				'key'   => '_airstory_project_id',

--- a/tests/PHPUnit/CoreTest.php
+++ b/tests/PHPUnit/CoreTest.php
@@ -34,6 +34,8 @@ class CoreTest extends \Airstory\TestCase {
 		// Disect key parts of the resulting query args.
 		$this->assertEquals( array( 'draft', 'pending' ), WP_Query::$__query['post_status'], 'get_current_draft() should never retrieve a published post ID' );
 		$this->assertEquals( 'ids', WP_Query::$__query['fields'], 'get_current_draft() should only query post IDs' );
+		$this->assertEquals( 'date', WP_Query::$__query['orderby'], 'get_current_draft() should only query post IDs' );
+		$this->assertEquals( 'ASC', WP_Query::$__query['order'], 'get_current_draft() should only query post IDs' );
 
 		// Break down the meta query
 		$this->assertCount( count( $meta_query ), WP_Query::$__query['meta_query'] );


### PR DESCRIPTION
Ensure Core\get_current_draft() always selects the *oldest* draft that matches the given document + project IDs. Fixes #2