### PR TITLE
Refactoring of uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -63,9 +63,10 @@ function get_active_site_ids() {
  */
 function disconnect_all_users() {
 	$user_args       = array(
-		'fields'     => 'ID',
-		'number'     => 100,
-		'meta_query' => array(
+		'fields'      => 'ID',
+		'number'      => 100,
+		'count_total' => false,
+		'meta_query'  => array(
 			array(
 				'key'     => '_airstory_target',
 				'compare' => 'EXISTS',
@@ -80,7 +81,7 @@ function disconnect_all_users() {
 
 		Connection\remove_connection( $user_id );
 
-		// If we've reached the end, get the next page.
+		// If we've reached the end, get the next batch.
 		if ( empty( $user_ids ) ) {
 			$connected_users = new \WP_User_Query( $user_args );
 			$user_ids        = $connected_users->results;

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,7 +10,9 @@
 
 namespace Airstory;
 
+require_once __DIR__ . '/includes/class-api.php';
 require_once __DIR__ . '/includes/connection.php';
+require_once __DIR__ . '/includes/settings.php';
 
 global $wpdb;
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,9 +12,7 @@ namespace Airstory\Uninstall;
 
 use Airstory\Connection as Connection;
 
-require_once __DIR__ . '/includes/class-api.php';
 require_once __DIR__ . '/includes/connection.php';
-require_once __DIR__ . '/includes/settings.php';
 
 /**
  * Retrieve the IDs of any sites with active Airstory connections.


### PR DESCRIPTION
When preparing the beta release, I discovered #25, which was a bug introduced by the introduction of multisite support, which changed the structure of the Airstory user meta keys.

This total refactor of `uninstall.php` goes from being totally procedural (which was messy and difficult to test) to using functions for the main actions, with minimal logic at the bottom of the file to apply it. In the process, it fixes #25.

Before it comes up, the function definitions come before the `WP_UNINSTALL_PLUGIN` constant check purely for testability — since this file should never be included directly, I don't mind _defining_ three functions before we check the constant that says "oh, are you supposed to be here?" This allows us to test each of the functions in isolation, while short-circuiting the raw-procedural code at the bottom of the file (which is then tested by the `testUninstall()` methods).