### PR TITLE
Force HTTPS scheme when generating REST API URL

### DIFF
--- a/includes/connection.php
+++ b/includes/connection.php
@@ -60,7 +60,7 @@ function get_target( $user_id ) {
 	return array(
 		'identifier' => (string) $user_id, // Airstory expects a string.
 		'name'       => get_bloginfo( 'name' ),
-		'url'        => get_rest_url( null, '/airstory/v1/webhook' ),
+		'url'        => get_rest_url( null, '/airstory/v1/webhook', 'https' ),
 		'type'       => 'wordpress',
 	);
 }

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -110,7 +110,7 @@ class ConnectionTest extends \Airstory\TestCase {
 		) );
 
 		M::userFunction( 'get_rest_url', array(
-			'args'   => array( null, '/airstory/v1/webhook' ),
+			'args'   => array( null, '/airstory/v1/webhook', 'https' ),
 			'return' => 'http://example.com/airstory/v1/webhook'
 		) );
 


### PR DESCRIPTION
Thanks to #34 making HTTPS support a requirement for WordPress sites running the Airstory plugin, this PR ensures the REST API endpoint sent to Airstory when we establish a connection uses the HTTPS version of the URL.

The code in this PR is light, I'm opening it more for the sake of conversation and sanity checking 😄  — if I'm not mistaken, this PR fixes #33.