### PR TITLE
Improve error reporting on the webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file, according t
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+* Improve error messaging around the webhook, making it easier to troubleshoot connection issues.
+
+
 ## [1.0.1]
 
 * Refactor the `grunt build` task to include the readme.txt file and skip the `dist/` directory when building the plugin's language files.

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -61,9 +61,16 @@ function handle_webhook( WP_REST_Request $request ) {
 		return $error;
 	}
 
+	// Retrieve the decrypted user token.
+	$user_token = Credentials\get_token( $identifier );
+
+	if ( is_wp_error( $user_token ) ) {
+		return $user_token;
+	}
+
 	// Establish an API connection, using the Airstory token of the connection owner.
 	$api = new Airstory\API;
-	$api->set_token( Credentials\get_token( $identifier ) );
+	$api->set_token( $user_token );
 
 	// Determine if there's a current post that matches.
 	$post_id = Core\get_current_draft( $project, $document );

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -66,6 +66,11 @@ function handle_webhook( WP_REST_Request $request ) {
 
 	if ( is_wp_error( $user_token ) ) {
 		return $user_token;
+	} elseif ( empty( $user_token ) ) {
+		return new WP_Error(
+			'airstory-missing-token',
+			__( 'The current user has not provided an Airstory user token', 'airstory' )
+		);
 	}
 
 	// Establish an API connection, using the Airstory token of the connection owner.

--- a/tests/PHPUnit/WebhookTest.php
+++ b/tests/PHPUnit/WebhookTest.php
@@ -87,6 +87,33 @@ class WebhookTest extends \Airstory\TestCase {
 		$this->assertEquals( 'http://example.com/edit?id=123', $response['edit_url'], 'The post edit URL should be returned' );
 	}
 
+	public function testHandleWebhookChecksThatIdentifierIsSet() {
+		$request = Mockery::mock( 'WP_REST_Request' )->makePartial();
+		$request->shouldReceive( 'get_param' )->with( 'identifier' )->andReturn( null );
+		$request->shouldReceive( 'get_param' )->with( 'project' )->andReturn( 'project' );
+		$request->shouldReceive( 'get_param' )->with( 'document' )->andReturn( 'doc' );
+
+		$this->assertInstanceOf( 'WP_Error', handle_webhook( $request ) );
+	}
+
+	public function testHandleWebhookChecksThatProjectIsSet() {
+		$request = Mockery::mock( 'WP_REST_Request' )->makePartial();
+		$request->shouldReceive( 'get_param' )->with( 'identifier' )->andReturn( 5 );
+		$request->shouldReceive( 'get_param' )->with( 'project' )->andReturn( null );
+		$request->shouldReceive( 'get_param' )->with( 'document' )->andReturn( 'doc' );
+
+		$this->assertInstanceOf( 'WP_Error', handle_webhook( $request ) );
+	}
+
+	public function testHandleWebhookChecksThatDocumentIsSet() {
+		$request = Mockery::mock( 'WP_REST_Request' )->makePartial();
+		$request->shouldReceive( 'get_param' )->with( 'identifier' )->andReturn( 5 );
+		$request->shouldReceive( 'get_param' )->with( 'project' )->andReturn( 'project' );
+		$request->shouldReceive( 'get_param' )->with( 'document' )->andReturn( null );
+
+		$this->assertInstanceOf( 'WP_Error', handle_webhook( $request ) );
+	}
+
 	public function testHandleWebhookUpdatesExistingDocs() {
 		$project  = 'pXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
 		$document = 'dXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';


### PR DESCRIPTION
Up to this point, when Airstory sends a `POST` request to the webhook endpoint, it receives either:
1. A JSON response with the project ID, document ID, WordPress post ID, and the post's edit URL
2. A `WP_Error` response if the webhook was unable to import the document.

This pull request improves the behavior, ensuring that `WP_Error` objects are issued when the logic fails at any point along the way, including:
* One or more required arguments missing from the `POST` request
* Unable to decrypt the user token
* User token for the current user not being set

With this better reporting in place, Airstory's able to more effectively guide users when something goes wrong (e.g. "It appears you haven't entered your Airstory into your user token, please visit https://example.com/wp-admin/profile.php#airstory and do so"), and we can more effectively troubleshoot when things go wrong.