### PR TITLE
Include the plugin version just below the 'Airstory' header on the tools page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file, according t
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+* Add the plugin version to the header of the Tools > Airstory page.
+
+
 ## [1.0.1]
 
 * Refactor the `grunt build` task to include the readme.txt file and skip the `dist/` directory when building the plugin's language files.

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -43,6 +43,11 @@ function render_tools_page() {
 
 	<div class="wrap">
 		<h1><?php echo esc_html( _x( 'Airstory', 'tools page heading', 'airstory' ) ); ?></h1>
+		<p class="description"><?php echo esc_html( sprintf(
+			/* Translators: %1$s is the current plugin version. */
+			__( 'Version %1$s', 'airstory' ),
+			AIRSTORY_VERSION
+		) ); ?></p>
 		<p><?php esc_html_e( 'This page contains useful information for integrating Airstory into WordPress.', 'airstory' ); ?></p>
 
 		<h2><?php echo esc_html( _x( 'Compatibility', 'tools page heading', 'airstory' ) ); ?></h2>


### PR DESCRIPTION
We've received a few bug reports that include a screenshot of the top half of the tools page; this will help ensure the version is always prominent, in case the user is running an older version.