### PR TITLE
Connectivity checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+* Introduce two connectivity checks in the "Compatibility" table to help identify issues accessing either the Airstory API or the WP REST API.
 * Add the plugin version to the header of the Tools > Airstory page.
 
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ module.exports = function(grunt) {
 		copy: {
 			main: {
 				src: [
+					'assets/**',
 					'includes/**',
 					'languages/**',
 					'airstory.php',

--- a/assets/js/tools.js
+++ b/assets/js/tools.js
@@ -1,0 +1,40 @@
+/**
+ * Scripting for the Tools > Airstory page.
+ *
+ * @package Airstory
+ * @author  Liquid Web
+ */
+ /* global airstoryTools */
+
+( function () {
+	'use strict';
+
+	/**
+	 * Given a URL and a DOM element, send an asynchronous request to the URL to ensure
+	 * this site can communicate.
+	 *
+	 * @param {string} url - The URL to request.
+	 * @param {Element} el - The DOM element to be updated with the result.
+	 */
+	var checkConnectivity = function ( url, el ) {
+		var xhr = new XMLHttpRequest();
+
+		xhr.open( 'HEAD', url, true );
+		xhr.onload = function () {
+			el.innerHTML = airstoryTools.statusIcons.success;
+		}
+
+		xhr.onerror = function () {
+			el.innerHTML = airstoryTools.statusIcons.failure;
+		}
+
+		xhr.send();
+	};
+
+	// Verify connectivity with this site's WP REST API.
+	checkConnectivity( airstoryTools.restApiUrl, document.getElementById( 'airstory-restapi-check' ) );
+
+	// Outbound communication with Airstory's API.
+	checkConnectivity( 'https://api.airstory.co/v1', document.getElementById( 'airstory-connection-check' ) );
+
+} )();

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -23,9 +23,33 @@ function register_menu_page() {
 add_action( 'admin_menu', __NAMESPACE__ . '\register_menu_page' );
 
 /**
+ * Register the tools scripting.
+ */
+function register_tools_script() {
+	wp_register_script(
+		'airstory-tools',
+		plugins_url( 'assets/js/tools.js', __DIR__ ),
+		null,
+		AIRSTORY_VERSION,
+		true
+	);
+
+	wp_localize_script( 'airstory-tools', 'airstoryTools', array(
+		'restApiUrl'  => get_rest_url( null, '/airstory/v1', 'https' ),
+		'statusIcons' => array(
+			'loading' => '',
+			'success' => render_status_icon( true, false ),
+			'failure' => render_status_icon( false, false ),
+		),
+	) );
+}
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\register_tools_script' );
+
+/**
  * Render the content for the "Airstory" tools page.
  */
 function render_tools_page() {
+	wp_enqueue_script( 'airstory-tools' );
 	$compatibility = check_compatibility();
 ?>
 
@@ -109,6 +133,22 @@ function render_tools_page() {
 					</tr>
 
 				<?php endforeach; ?>
+
+				<tr>
+					<td><?php esc_html_e( 'WordPress REST API', 'airstory' ); ?></td>
+					<td><?php esc_html_e( 'Is this site\'s REST API accessible via HTTPS?', 'airstory' ); ?></td>
+					<td id="airstory-restapi-check">
+						<img src="<?php echo esc_url( admin_url( 'images/spinner-2x.gif' ) ); ?>" alt="<?php esc_attr_e( 'Loading', 'airstory' ); ?>" width="20" />
+					</td>
+				</tr>
+
+				<tr>
+					<td><?php esc_html_e( 'Airstory connection', 'airstory' ); ?></td>
+					<td><?php esc_html_e( 'Can this site communicate with Airstory?', 'airstory' ); ?></td>
+					<td id="airstory-connection-check">
+						<img src="<?php echo esc_url( admin_url( 'images/spinner-2x.gif' ) ); ?>" alt="<?php esc_attr_e( 'Loading', 'airstory' ); ?>" width="20" />
+					</td>
+				</tr>
 			</tbody>
 		</table>
 

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -134,8 +134,12 @@ function render_tools_page() {
  *
  * @param mixed $status The state of the option — TRUE will create a check mark, FALSE will produce
  *                      an "X". Non-Boolean values will be cast as Booleans.
+ * @param bool  $echo   Optional. Output the icon directly to the browser, or return it? Default
+ *                      is true.
+ * @return void|string  Depending on $echo, either the function will return nothing or return a
+ *                      string containing the status icon.
  */
-function render_status_icon( $status ) {
+function render_status_icon( $status, $echo = true ) {
 
 	if ( (bool) $status ) {
 		$icon = 'yes';
@@ -146,11 +150,17 @@ function render_status_icon( $status ) {
 		$msg  = _x( 'Failed', 'dependency check status', 'airstory' );
 	}
 
-	echo wp_kses_post( sprintf(
+	$output = sprintf(
 		'<span class="dashicons dashicons-%s"></span><span class="screen-reader-text">%s</span>',
 		esc_attr( $icon ),
 		esc_html( $msg )
-	) );
+	);
+
+	if ( ! $echo ) {
+		return $output;
+	}
+
+	echo wp_kses_post( $output );
 }
 
 /**

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -13,6 +13,7 @@
 	<file>includes</file>
 	<exclude-pattern>includes/lib/*</exclude-pattern>
 
+	<exclude-pattern>assets/*</exclude-pattern>
 	<exclude-pattern>languages/*</exclude-pattern>
 	<exclude-pattern>plugin-repo-assets/*</exclude-pattern>
 	<exclude-pattern>tests/*</exclude-pattern>


### PR DESCRIPTION
Based on some support requests I've fielded this week, I've added two new rows to the compatibility check:

1. Verify that the browser is able to connect to the current site's WP REST API over HTTPS — this was the cause of #36, and several users who are on shared hosting with broken/missing SSL certificates have run into problems. This should help notify people immediately if there might be a problem, _before_ they try to export to WordPress.
2. The Airstory API, to ensure the site is able to communicate with Airstory.

The second point requires a little more work, thanks to our old friend CORS. There are two ways we can go about this:

1. @stevendluke [adds the appropriate CORS headers](https://enable-cors.org/) to enable, for instance, a HEAD request to https://api.airstory.co/v1 via XMLHttpRequest), allowing users to basically say "hey, API — you up?"
2. We add a server-side proxy and count a 403 status code as "well, at least it's there to tell us we're not permitted to access it."

My personal preference would be the CORS headers (especially if future API goodness is to come), but I'll leave that at his discretion. In the meantime, the rest of the PR is ready for code review.