### PR TITLE
Refactoring of save_profile_settings()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Introduce two connectivity checks in the "Compatibility" table to help identify issues accessing either the Airstory API or the WP REST API.
 * Improve error messaging around the webhook, making it easier to troubleshoot connection issues.
 * Add the plugin version to the header of the Tools > Airstory page.
+* Refactor the logic when saving user settings.
 
 
 ## [1.0.1]

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -168,11 +168,8 @@ function save_profile_settings( $user_id ) {
 		return false;
 	}
 
-	$token = get_user_data( $user_id, 'user_token', false );
-
-	// The user is disconnecting.
-	if ( $token && isset( $_POST['airstory-disconnect'] ) ) {
-
+	// The user is attempting to disconnect.
+	if ( isset( $_POST['airstory-disconnect'] ) ) {
 		// Clear out all connections.
 		Connection\set_connected_blogs( $user_id, array() );
 
@@ -186,8 +183,10 @@ function save_profile_settings( $user_id ) {
 		Credentials\clear_token( $user_id );
 
 		return delete_user_option( $user_id, '_airstory_data', true );
+	}
 
-	} elseif ( ! empty( $_POST['airstory-token'] ) ) {
+	// The user is setting their token.
+	if ( ! empty( $_POST['airstory-token'] ) ) {
 		Credentials\set_token( $user_id, sanitize_text_field( $_POST['airstory-token'] ) );
 	}
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -102,7 +102,7 @@ function render_profile_settings( $user ) {
 				<td>
 					<?php if ( ! empty( $profile['email'] ) ) : ?>
 
-						<input name="airstory-disconnect" type="submit" class="button" value="<?php esc_attr_e( 'Disconnect from Airstory', '' ); ?>" />
+						<input name="airstory-disconnect" type="submit" class="button" value="<?php esc_attr_e( 'Disconnect from Airstory', 'airstory' ); ?>" />
 						<p class="description">
 							<?php echo wp_kses_post( sprintf(
 								/* Translators: %1$s is the user's Airstory email address. */

--- a/tests/PHPUnit/SettingsTest.php
+++ b/tests/PHPUnit/SettingsTest.php
@@ -221,11 +221,6 @@ class SettingsTest extends \Airstory\TestCase {
 			'return' => true,
 		) );
 
-		M::userFunction( __NAMESPACE__ . '\get_user_data', array(
-			'args'   => array( 123, 'user_token', false ),
-			'return' => array( 'token' => 'my-old-token' ),
-		) );
-
 		M::userFunction( 'Airstory\Credentials\set_token', array(
 			'times'  => 1,
 			'args'   => array( 123, 'my-secret-token' ),
@@ -384,11 +379,6 @@ class SettingsTest extends \Airstory\TestCase {
 
 		M::userFunction( 'current_user_can', array(
 			'return' => true,
-		) );
-
-		M::userFunction( __NAMESPACE__ . '\get_user_data', array(
-			'args'   => array( 123, 'user_token', '*' ),
-			'return' => array( 'token' => 'my-old-token' ),
 		) );
 
 		M::userFunction( 'Airstory\Connection\set_connected_blogs', array(


### PR DESCRIPTION
The logic was a bit fuzzy before when running `save_profile_settings()`, so this PR aims to simplify it:

1. If the nonce isn't set, doesn't verify, or the user doesn't have permission to edit the current user (which should always be themselves, but 🤷‍♂️ ), return early.
2. If `$_POST['airstory_token']` is empty *and* `$_POST['airstory_disconnect']` is not set, there's nothing to do, so return early (preserves @norcross' work from #38).
3. If `$_POST['airstory_disconnect']` is set (e.g. the user clicked the "disconnect from Airstory" button), clean up the connections and user data for the user.
4. If `$_POST['airstory_token']` is not empty, set the token value and establish the connection to Airstory. *Do not return yet!*
5. If we're in multisite and the user has opted to connect multiple sites, establish those connections. *Do not return yet!*

Finally, if we made it past condition 3, fire the `airstory_user_connect` action and return `true`.

The main reason for this refactoring was to help simplify the logic when saving and prevent situations in which a user might not be able to save his/her token (a case one user has reported but I've had difficulty reproducing).

BTW, The diffs in the PR don't really do it justice, so you might want to look at the full body of the function.