### PR TITLE
Verify libxml version >= 2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 * Improve support for accented and non-Latin characters when importing into WordPress.
+* Add explicit check for libxml >= 2.7.8, as versions before that don't support the `LIBXML_HTML_NODEFDTD` constant.
 * Clean up coding standards.
 
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin enables [Airstory](http://www.airstory.co/) users to connect their W
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Get one project free for life, just by signing up!](http://www.airstory.co/pricing/)
 * PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
+* Libxml version 2.7.8 or higher.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -90,7 +90,7 @@ function render_tools_page() {
 					<td><?php esc_html_e( 'PHP Version >= 5.3', 'airstory' ); ?></td>
 					<td><?php echo esc_html( sprintf(
 						/* Translators: %1$s is the current PHP version. */
-						__( 'Version %1$s', 'airstory' ),
+						_x( 'Version %1$s', 'PHP version', 'airstory' ),
 						PHP_VERSION
 					) ); ?></td>
 					<td><?php render_status_icon( $compatibility['details']['php'] ); ?></td>
@@ -109,6 +109,17 @@ function render_tools_page() {
 					<td><?php render_status_icon( $compatibility['details']['https'] ); ?></td>
 				</tr>
 				<?php unset( $compatibility['details']['https'] ); ?>
+
+				<tr class="dependency-<?php echo esc_attr( $compatibility['details']['libxml'] ? 'met' : 'unmet' ); ?>">
+					<td><?php esc_html_e( 'Libxml version >= 2.7.8' ); ?></td>
+					<td><?php echo esc_html( sprintf(
+						/* Translators: %1$s is the current libxml version. */
+						_x( 'Version %1$s', 'libxml version', 'airstory' ),
+						LIBXML_DOTTED_VERSION
+					) ); ?></td>
+					<td><?php render_status_icon( $compatibility['details']['libxml'] ); ?></td>
+				</tr>
+				<?php unset( $compatibility['details']['libxml'] ); ?>
 
 				<?php foreach ( array_keys( $compatibility['details'] ) as $ext ) : // Everything left is an extension. ?>
 
@@ -358,6 +369,7 @@ function get_support_details() {
 	$report .= 'Requirements:' . PHP_EOL;
 	$report .= '- PHP >= 5.3         ' . ( $compatibility['details']['php'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- HTTPS support      ' . ( $compatibility['details']['https'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
+	$report .= '- Libxml >= 2.7.8    ' . ( $compatibility['details']['libxml'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- DOM Extension      ' . ( $compatibility['details']['dom'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- Mcrypt Extension   ' . ( $compatibility['details']['mcrypt'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- OpenSSL Extension  ' . ( $compatibility['details']['openssl'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
@@ -431,6 +443,7 @@ function get_support_details() {
 	$report .= 'PHP Version:         ' . PHP_VERSION . PHP_EOL;
 	$report .= 'MySQL Version:       ' . $wpdb->db_version() . PHP_EOL;
 	$report .= 'Web Server:          ' . $_SERVER['SERVER_SOFTWARE'] . PHP_EOL;
+	$report .= 'Libxml version       ' . LIBXML_DOTTED_VERSION . PHP_EOL;
 
 	// PHP Configuration.
 	$report .= PHP_EOL . '-- PHP Configuration' . PHP_EOL . PHP_EOL;

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -253,6 +253,13 @@ function check_compatibility() {
 		}
 	}
 
+	// Verify libxml version.
+	$compatibility['details']['libxml'] = defined( 'LIBXML_VERSION' ) && version_compare( LIBXML_VERSION, '2.7.8', '>=' );
+
+	if ( ! $compatibility['details']['libxml'] ) {
+		$compatibility['compatible'] = false;
+	}
+
 	return $compatibility;
 }
 

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -87,7 +87,7 @@ function render_tools_page() {
 			<tbody>
 
 				<tr class="dependency-<?php echo esc_attr( $compatibility['details']['php'] ? 'met' : 'unmet' ); ?>">
-					<td><?php esc_html_e( 'PHP Version >= 5.3', 'airstory' ); ?></td>
+					<td><?php esc_html_e( 'PHP 5.3 or higher', 'airstory' ); ?></td>
 					<td><?php echo esc_html( sprintf(
 						/* Translators: %1$s is the current PHP version. */
 						_x( 'Version %1$s', 'PHP version', 'airstory' ),
@@ -111,7 +111,7 @@ function render_tools_page() {
 				<?php unset( $compatibility['details']['https'] ); ?>
 
 				<tr class="dependency-<?php echo esc_attr( $compatibility['details']['libxml'] ? 'met' : 'unmet' ); ?>">
-					<td><?php esc_html_e( 'Libxml version >= 2.7.8' ); ?></td>
+					<td><?php esc_html_e( 'Libxml 2.7.8 or higher' ); ?></td>
 					<td><?php echo esc_html( sprintf(
 						/* Translators: %1$s is the current libxml version. */
 						_x( 'Version %1$s', 'libxml version', 'airstory' ),

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -254,7 +254,7 @@ function check_compatibility() {
 	}
 
 	// Verify libxml version.
-	$compatibility['details']['libxml'] = defined( 'LIBXML_VERSION' ) && version_compare( LIBXML_VERSION, '2.7.8', '>=' );
+	$compatibility['details']['libxml'] = defined( 'LIBXML_DOTTED_VERSION' ) && version_compare( LIBXML_DOTTED_VERSION, '2.7.8', '>=' );
 
 	if ( ! $compatibility['details']['libxml'] ) {
 		$compatibility['compatible'] = false;

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,7 @@ Airstory is a paid solution, which includes support and integrations, like this 
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Get one project free for life, just by signing up!](http://www.airstory.co/pricing/)
 * PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
+* Libxml version 2.7.8 or higher.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/tests/PHPUnit/ToolsTest.php
+++ b/tests/PHPUnit/ToolsTest.php
@@ -75,10 +75,18 @@ class ToolsTest extends \Airstory\TestCase {
 
 	/**
 	 * @runInSeparateProcess
+	 *
+	 * @link https://github.com/liquidweb/airstory-wp/issues/48
 	 */
 	public function testCheckCompatibilityWithLibxml() {
 		M::userFunction( __NAMESPACE__ . '\version_compare', array(
-			'return_in_order' => array( true, false ),
+			'args'   => array( PHP_VERSION, '*', '*' ),
+			'return' => true,
+		) );
+
+		M::userFunction( __NAMESPACE__ . '\version_compare', array(
+			'args'   => array( LIBXML_DOTTED_VERSION, '*', '>=' ),
+			'return' => false,
 		) );
 
 		M::userFunction( __NAMESPACE__ . '\verify_https_support', array(

--- a/tests/PHPUnit/ToolsTest.php
+++ b/tests/PHPUnit/ToolsTest.php
@@ -76,6 +76,24 @@ class ToolsTest extends \Airstory\TestCase {
 	/**
 	 * @runInSeparateProcess
 	 */
+	public function testCheckCompatibilityWithLibxml() {
+		M::userFunction( __NAMESPACE__ . '\version_compare', array(
+			'return_in_order' => array( true, false ),
+		) );
+
+		M::userFunction( __NAMESPACE__ . '\verify_https_support', array(
+			'return' => true,
+		) );
+
+		$compatibility = check_compatibility();
+
+		$this->assertFalse( $compatibility['compatible'] );
+		$this->assertFalse( $compatibility['details']['libxml'] );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 */
 	public function testCheckCompatibilityWithDom() {
 		M::userFunction( __NAMESPACE__ . '\extension_loaded', array(
 			'return' => false,


### PR DESCRIPTION
Based on the error report we received in #48, there may be instances of Airstory users running older (as in, pre-late 2010) versions of libxml. [The `LIBXML_HTML_NODEFDTD` constant isn't defined in versions prior to 2.7.8](http://php.net/manual/en/libxml.constants.php#constant.libxml-html-nodefdtd), which could be the cause of this issue.

This PR adds considerations for the libxml version to the plugin's compatibility check logic.