### PR TITLE
Add support for alternate OpenSSL cipher algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 * Explicitly import `WP_Error` into `Airstory\Credentials`.
+* Add fallback cipher algorithms for environments running older versions of OpenSSL.
 
 
 ## [1.1.2]

--- a/tests/PHPUnit/CredentialsTest.php
+++ b/tests/PHPUnit/CredentialsTest.php
@@ -40,7 +40,11 @@ class CredentialsTest extends \Airstory\TestCase {
 	public function testSetToken() {
 		$token     = uniqid();
 		$iv        = '1234567890123456';
-		$encrypted = openssl_encrypt( $token, AIRSTORY_ENCRYPTION_ALGORITHM, AUTH_KEY, null, $iv );
+		$encrypted = openssl_encrypt( $token, 'AES-256-CTR', AUTH_KEY, null, $iv );
+
+		M::userFunction( __NAMESPACE__ . '\get_cipher_algorithm', array(
+			'return' => 'AES-256-CTR',
+		) );
 
 		M::userFunction( __NAMESPACE__ . '\get_iv', array(
 			'return' => $iv,
@@ -61,7 +65,11 @@ class CredentialsTest extends \Airstory\TestCase {
 	public function testGetToken() {
 		$token     = uniqid();
 		$iv        = '1234567890123456';
-		$encrypted = openssl_encrypt( $token, AIRSTORY_ENCRYPTION_ALGORITHM, AUTH_KEY, null, $iv );
+		$encrypted = openssl_encrypt( $token, 'AES-256-CTR', AUTH_KEY, null, $iv );
+
+		M::userFunction( __NAMESPACE__ . '\get_cipher_algorithm', array(
+			'return' => 'AES-256-CTR',
+		) );
 
 		M::userFunction( 'get_user_by', array(
 			'args'   => array( 'ID', 123 ),

--- a/tests/PHPUnit/UninstallTest.php
+++ b/tests/PHPUnit/UninstallTest.php
@@ -103,6 +103,11 @@ class UninstallTest extends \Airstory\TestCase {
 			->once()
 			->with( "DELETE FROM usermeta_table WHERE meta_key = '_airstory_data';" );
 
+		M::userFunction( 'delete_site_option', array(
+			'times' => 1,
+			'args'  => array( '_airstory_cipher_algorithm' ),
+		) );
+
 		$this->bootstrap();
 		delete_airstory_data();
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -98,6 +98,9 @@ function delete_airstory_data() {
 	global $wpdb;
 
 	$wpdb->query( "DELETE FROM $wpdb->usermeta WHERE meta_key = '_airstory_data';" ); // WPCS: unprepared SQL ok.
+
+	// Remove the _airstory_encryption_algorithm site option.
+	delete_site_option( '_airstory_cipher_algorithm' );
 }
 
 // Prevent this file from being executed outside of the plugin uninstallation.


### PR DESCRIPTION
Rather than hard-code a secure (but not ubiquitous) cipher in the `AIRSTORY_ENCRYPTION_ALGORITHM` constant, this PR adds the `Airstory\Credentials\get_cipher_algorithm()` function, which will find a suitable algorithm from a list of common-yet-acceptable options.

Once the algorithm is determined, this value is saved to the database (via `add_site_option()`), then used on all subsequent encryption/decryption requests. This practice ensures that once a site settles on an algorithm the *same* algorithm will be used moving forward.

This PR also adds additional tests around error cases when encrypting/decrypting user tokens, plus ensures that the cipher algorithm saved to the database is removed if the plugin is uninstalled. Fixes #53.