### PR TITLE
Reduce libxml requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Explicitly import `WP_Error` into `Airstory\Credentials`.
 * Add fallback cipher algorithms for environments running older versions of OpenSSL.
+* Remove requirement for libxml 2.7.8 or newer, which was introduced in version [1.1.1].
 
 
 ## [1.1.2]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This plugin enables [Airstory](http://www.airstory.co/) users to connect their W
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Get one project free for life, just by signing up!](http://www.airstory.co/pricing/)
 * PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
-* Libxml version 2.7.8 or higher.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -174,7 +174,7 @@ function sideload_all_images( $post_id ) {
 	 */
 	$use_internal = libxml_use_internal_errors( true );
 	$body         = new \DOMDocument;
-	$body->loadHTML( '<div>' . $post->post_content . '</div>', LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED );
+	$body->loadHTML( '<div>' . $post->post_content . '</div>', LIBXML_HTML_NODEFDTD );
 	$images       = $body->getElementsByTagName( 'img' );
 	$domains      = array( 'images.airstory.co', 'res.cloudinary.com' );
 	$replaced     = array();

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -174,7 +174,7 @@ function sideload_all_images( $post_id ) {
 	 */
 	$use_internal = libxml_use_internal_errors( true );
 	$body         = new \DOMDocument;
-	$body->loadHTML( '<div>' . $post->post_content . '</div>', LIBXML_HTML_NODEFDTD );
+	$body->loadHTML( '<div>' . $post->post_content . '</div>' );
 	$images       = $body->getElementsByTagName( 'img' );
 	$domains      = array( 'images.airstory.co', 'res.cloudinary.com' );
 	$replaced     = array();

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -39,7 +39,7 @@ function get_body_contents( $content ) {
 	$content = wp_encode_emoji( $content );
 
 	$doc = new \DOMDocument( '1.0', 'UTF-8' );
-	$doc->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ), LIBXML_HTML_NODEFDTD );
+	$doc->loadHTML( mb_convert_encoding( $content, 'HTML-ENTITIES', 'UTF-8' ) );
 
 	// Will retrieve the entire <body> node.
 	$body_node = $doc->getElementsByTagName( 'body' );

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -110,17 +110,6 @@ function render_tools_page() {
 				</tr>
 				<?php unset( $compatibility['details']['https'] ); ?>
 
-				<tr class="dependency-<?php echo esc_attr( $compatibility['details']['libxml'] ? 'met' : 'unmet' ); ?>">
-					<td><?php esc_html_e( 'Libxml 2.7.8 or higher' ); ?></td>
-					<td><?php echo esc_html( sprintf(
-						/* Translators: %1$s is the current libxml version. */
-						_x( 'Version %1$s', 'libxml version', 'airstory' ),
-						LIBXML_DOTTED_VERSION
-					) ); ?></td>
-					<td><?php render_status_icon( $compatibility['details']['libxml'] ); ?></td>
-				</tr>
-				<?php unset( $compatibility['details']['libxml'] ); ?>
-
 				<?php foreach ( array_keys( $compatibility['details'] ) as $ext ) : // Everything left is an extension. ?>
 
 					<tr class="dependency-<?php echo esc_attr( $compatibility['details'][ $ext ] ? 'met' : 'unmet' ); ?>">
@@ -264,13 +253,6 @@ function check_compatibility() {
 		}
 	}
 
-	// Verify libxml version.
-	$compatibility['details']['libxml'] = defined( 'LIBXML_DOTTED_VERSION' ) && version_compare( LIBXML_DOTTED_VERSION, '2.7.8', '>=' );
-
-	if ( ! $compatibility['details']['libxml'] ) {
-		$compatibility['compatible'] = false;
-	}
-
 	return $compatibility;
 }
 
@@ -369,7 +351,6 @@ function get_support_details() {
 	$report .= 'Requirements:' . PHP_EOL;
 	$report .= '- PHP >= 5.3         ' . ( $compatibility['details']['php'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- HTTPS support      ' . ( $compatibility['details']['https'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
-	$report .= '- Libxml >= 2.7.8    ' . ( $compatibility['details']['libxml'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- DOM Extension      ' . ( $compatibility['details']['dom'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- Mcrypt Extension   ' . ( $compatibility['details']['mcrypt'] ? 'PASS' : 'FAIL' ) . PHP_EOL;
 	$report .= '- OpenSSL Extension  ' . ( $compatibility['details']['openssl'] ? 'PASS' : 'FAIL' ) . PHP_EOL;

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,6 @@ Airstory is a paid solution, which includes support and integrations, like this 
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Get one project free for life, just by signing up!](http://www.airstory.co/pricing/)
 * PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
-* Libxml version 2.7.8 or higher.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/tests/PHPUnit/ToolsTest.php
+++ b/tests/PHPUnit/ToolsTest.php
@@ -75,32 +75,6 @@ class ToolsTest extends \Airstory\TestCase {
 
 	/**
 	 * @runInSeparateProcess
-	 *
-	 * @link https://github.com/liquidweb/airstory-wp/issues/48
-	 */
-	public function testCheckCompatibilityWithLibxml() {
-		M::userFunction( __NAMESPACE__ . '\version_compare', array(
-			'args'   => array( PHP_VERSION, '*', '*' ),
-			'return' => true,
-		) );
-
-		M::userFunction( __NAMESPACE__ . '\version_compare', array(
-			'args'   => array( LIBXML_DOTTED_VERSION, '*', '>=' ),
-			'return' => false,
-		) );
-
-		M::userFunction( __NAMESPACE__ . '\verify_https_support', array(
-			'return' => true,
-		) );
-
-		$compatibility = check_compatibility();
-
-		$this->assertFalse( $compatibility['compatible'] );
-		$this->assertFalse( $compatibility['details']['libxml'] );
-	}
-
-	/**
-	 * @runInSeparateProcess
 	 */
 	public function testCheckCompatibilityWithDom() {
 		M::userFunction( __NAMESPACE__ . '\extension_loaded', array(


### PR DESCRIPTION
Remove unnecessary libxml constants which were forcing the Airstory plugin to require libxml >= 2.7.8, causing problems for users trying to run it on CentOS 6 (which is locked into version 2.7.6).

The two constants in questions were for convenience, preventing DOMDocument from injecting a default doctype and/or `<html />` and `<body />` elements. Fortunately, we're injecting (and then subsequently targeting) wrapping elements around the items we need to control, thus working around this behavior without needing the incompatible constants.

Yet another case where unit tests have saved our butts!

Fixes #56.