### PR TITLE
Better handling of WP_Errors in Airstory API responses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Explicitly import `WP_Error` into `Airstory\Credentials`.
 * Add fallback cipher algorithms for environments running older versions of OpenSSL.
+* Better handling of `WP_Error` objects when decoding JSON responses from the Airstory API.
 
 
 ## [1.1.2]

--- a/includes/class-api.php
+++ b/includes/class-api.php
@@ -252,11 +252,18 @@ class API {
 	 * For requests that return JSON (e.g. anything except getting the generated HTML), JSON-decode
 	 * the API response and return it.
 	 *
-	 * @param array $response The HTTP response array.
+	 * @param array|WP_Error $response The HTTP response array, or a WP_Error object that might be
+	 *                                 passed from the HTTP request.
 	 * @return stdClass|WP_Error If JSON-decoded successfully, a stdClass representation of the
 	 *                           response body, otherwise a WP_Error object.
 	 */
 	protected function decode_json_response( $response ) {
+
+		// If we were given a WP_Error object, give it right back.
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		$result = json_decode( wp_remote_retrieve_body( $response ), false );
 
 		// Something went wrong decoding the JSON.


### PR DESCRIPTION
This PR ensures that if `wp_remote_request()` (called in `API::make_authenticated_request()`) returns a `WP_Error` object, `API::decode_json_response()` will return that error rather than attempting (and failing) to JSON-decode it.

Fixes #58.