### PR TITLE
Show error if unable to encrypt user token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file, according t
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [Unreleased]
+
+* Improved error handling if WordPress fails to authenticate with Airstory when saving the user token.
+
+
 ## [1.1.3]
 
 * Explicitly import `WP_Error` into `Airstory\Credentials`.

--- a/includes/connection.php
+++ b/includes/connection.php
@@ -16,6 +16,7 @@ namespace Airstory\Connection;
 use Airstory;
 use Airstory\Credentials as Credentials;
 use Airstory\Settings as Settings;
+use WP_Error;
 
 /**
  * Retrieve basic information about the user.
@@ -66,15 +67,6 @@ function get_target( $user_id ) {
 }
 
 /**
- * Display an error if the user was unable to authenticate with Airstory.
- *
- * @param WP_Error $errors Current user errors, passed by reference.
- */
-function user_connection_error( &$errors ) {
-	$errors->add( 'airstory-connection', __( 'WordPress was unable to authenticate with Airstory, please try again.', 'airstory' ) );
-}
-
-/**
  * Does the given user have a connection to Airstory?
  *
  * Note that this function does not check the validity of a connection, only whether or not one
@@ -97,6 +89,8 @@ function has_connection( $user_id ) {
  * Airstory account, and the target ID stored.
  *
  * @param int $user_id The ID of the user who has connected.
+ * @return string|WP_Error Either the GUID for the connection ID if registered successfully, or a
+ *                         WP_Error object explaining what went wrong.
  */
 function register_connection( $user_id ) {
 	if ( has_connection( $user_id ) ) {
@@ -106,9 +100,12 @@ function register_connection( $user_id ) {
 	$profile = get_user_profile( $user_id );
 
 	if ( empty( $profile ) ) {
-		add_action( 'user_profile_update_errors', __NAMESPACE__ . '\user_connection_error' );
+		add_action( 'user_profile_update_errors', 'Airstory\Settings\profile_error_save_token' );
 
-		return;
+		return new WP_Error(
+			'airstory-empty-profile',
+			__( 'User does not have an Airstory profile registered within WordPress.', 'airstory' )
+		);
 	}
 
 	$target        = get_target( $user_id );
@@ -116,7 +113,9 @@ function register_connection( $user_id ) {
 	$connection_id = $api->post_target( $profile['email'], $target );
 
 	if ( is_wp_error( $connection_id ) ) {
-		return;
+		add_action( 'user_profile_update_errors', 'Airstory\Settings\profile_error_save_token' );
+
+		return $connection_id;
 	}
 
 	// Store the profile and connection ID for the user.

--- a/includes/credentials.php
+++ b/includes/credentials.php
@@ -85,7 +85,8 @@ function get_iv() {
  *
  * @param int    $user_id The user ID.
  * @param string $token   The token to store for the user.
- * @return string The encrypted version of the token, which has been stored.
+ * @return string|WP_Error The encrypted version of the token, which has been stored. If the token
+ *                         could not be encrypted, a WP_Error object will be returned instead.
  */
 function set_token( $user_id, $token ) {
 	try {

--- a/includes/credentials.php
+++ b/includes/credentials.php
@@ -94,7 +94,7 @@ function set_token( $user_id, $token ) {
 		$encrypted = openssl_encrypt( $token, get_cipher_algorithm(), AUTH_KEY, null, $iv );
 
 		if ( false === $encrypted ) {
-			throw new Exception;
+			throw new Exception( __( 'Encrypted token was empty', 'airstory' ) );
 		}
 	} catch ( Exception $e ) {
 		return new WP_Error(

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -191,6 +191,8 @@ function save_profile_settings( $user_id ) {
 		$token_set = Credentials\set_token( $user_id, sanitize_text_field( $_POST['airstory-token'] ) );
 
 		if ( is_wp_error( $token_set ) ) {
+			add_action( 'user_profile_update_errors', __NAMESPACE__ . '\profile_error_save_token' );
+
 			return $token_set;
 		}
 	}
@@ -211,6 +213,19 @@ function save_profile_settings( $user_id ) {
 	return true;
 }
 add_action( 'personal_options_update', __NAMESPACE__ . '\save_profile_settings' );
+
+/**
+ * Add an error message to the user profile screen if the token could not be saved.
+ *
+ * @param WP_Error $errors WP_Error object, passed by reference.
+ */
+function profile_error_save_token( $errors ) {
+	$errors->add(
+		'airstory-save-token',
+		__( 'WordPress was unable to establish a connection with Airstory using the token provided', 'airstory' )
+	);
+}
+
 
 /**
  * Generate a list of blogs that $user_id is a member of *and* can publish to.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -11,6 +11,7 @@ use Airstory\Connection as Connection;
 use Airstory\Credentials as Credentials;
 use Airstory\Settings as Settings;
 use Airstory\Tools as Tools;
+use WP_Error;
 
 /**
  * Retrieve a value from the _airstory_data user meta key.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -188,7 +188,11 @@ function save_profile_settings( $user_id ) {
 
 	// The user is setting their token.
 	if ( ! empty( $_POST['airstory-token'] ) ) {
-		Credentials\set_token( $user_id, sanitize_text_field( $_POST['airstory-token'] ) );
+		$token_set = Credentials\set_token( $user_id, sanitize_text_field( $_POST['airstory-token'] ) );
+
+		if ( is_wp_error( $token_set ) ) {
+			return $token_set;
+		}
 	}
 
 	// If the user has access to more than one site, update them accordingly.

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -122,13 +122,6 @@ class ConnectionTest extends \Airstory\TestCase {
 		$this->assertEquals( 'wordpress', $response['type'] );
 	}
 
-	public function testUserConnectionError() {
-		$error = Mockery::mock( 'WP_Error' )->makePartial();
-		$error->shouldReceive( 'add' )->once();
-
-		user_connection_error( $error );
-	}
-
 	public function testHasConnection() {
 		M::userFunction( 'get_user_option', array(
 			'args'            => array( '_airstory_target', 5 ),
@@ -197,9 +190,9 @@ class ConnectionTest extends \Airstory\TestCase {
 			'return' => array(),
 		) );
 
-		M::expectActionAdded( 'user_profile_update_errors', __NAMESPACE__ . '\user_connection_error' );
+		M::expectActionAdded( 'user_profile_update_errors', 'Airstory\Settings\profile_error_save_token' );
 
-		$this->assertNull( register_connection( 123 ) );
+		$this->assertInstanceOf( 'WP_Error', register_connection( 123 ) );
 	}
 
 	public function testRegisterConnectionHandlesWPErrors() {
@@ -231,7 +224,9 @@ class ConnectionTest extends \Airstory\TestCase {
 			'return' => true,
 		) );
 
-		$this->assertNull( register_connection( 123 ) );
+		M::expectActionAdded( 'user_profile_update_errors', 'Airstory\Settings\profile_error_save_token' );
+
+		$this->assertInstanceOf( 'WP_Error', register_connection( 123 ) );
 	}
 
 	public function testRegisterConnectionChecksForExistingConnectionFirst() {

--- a/tests/PHPUnit/SettingsTest.php
+++ b/tests/PHPUnit/SettingsTest.php
@@ -427,7 +427,16 @@ class SettingsTest extends \Airstory\TestCase {
 			'return' => true,
 		) );
 
+		M::expectActionAdded( 'user_profile_update_errors', __NAMESPACE__ . '\profile_error_save_token' );
+
 		$this->assertSame( $error, save_profile_settings( 123 ) );
+	}
+
+	public function testProfileErrorSaveToken() {
+		$errors = Mockery::mock( 'WP_Error' )->makePartial();
+		$errors->shouldReceive( 'add' )->once()->with( 'airstory-save-token', Mockery::any() );
+
+		profile_error_save_token( $errors );
 	}
 
 	public function testGetAvailableBlogs() {

--- a/tests/PHPUnit/SettingsTest.php
+++ b/tests/PHPUnit/SettingsTest.php
@@ -9,6 +9,7 @@ namespace Airstory\Settings;
 
 use WP_Mock as M;
 use Mockery;
+use WP_Error;
 
 class SettingsTest extends \Airstory\TestCase {
 
@@ -400,6 +401,33 @@ class SettingsTest extends \Airstory\TestCase {
 		M::expectAction( 'airstory_user_disconnect', 123 );
 
 		$this->assertTrue( save_profile_settings( 123 ) );
+	}
+
+	public function testSaveProfileSettingsCatchesWPErrors() {
+		$_POST = array(
+			'_airstory_nonce' => 'abc123',
+			'airstory-token'  => 'my-secret-token',
+		);
+		$error = new WP_Error;
+
+		M::userFunction( 'wp_verify_nonce', array(
+			'return' => true,
+		) );
+
+		M::userFunction( 'current_user_can', array(
+			'return' => true,
+		) );
+
+		M::userFunction( 'Airstory\Credentials\set_token', array(
+			'return' => $error,
+		) );
+
+		M::userFunction( 'is_wp_error', array(
+			'args'   => array( $error ),
+			'return' => true,
+		) );
+
+		$this->assertSame( $error, save_profile_settings( 123 ) );
 	}
 
 	public function testGetAvailableBlogs() {


### PR DESCRIPTION
Instead of telling users that their profiles were updated successfully even when Airstory authentication failed, display a proper error message informing users of what went wrong; fixes #60.

There's definitely an opportunity to refactor some of the error handling here better, but it feels outside of the scope of a patch release. For now, the goal is to simply let people know that _something_ went wrong.