### PR TITLE
Full clean-up of user data following plugin uninstallation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Ensure content is being consistently converted to UTF-8 before performing any operations on it, drastically reducing some of the special character issues that have been reported by users.
 * Improved error handling if WordPress fails to authenticate with Airstory when saving the user token.
+* Fixed issue where not all user data was being removed on plugin uninstall.
 * Updated README files to reflect changes in Airstory's billing model.
 
 

--- a/includes/connection.php
+++ b/includes/connection.php
@@ -183,12 +183,10 @@ function remove_connection( $user_id ) {
 	$profile       = Settings\get_user_data( $user_id, 'profile', array() );
 	$connection_id = get_user_option( '_airstory_target', $user_id );
 
-	if ( empty( $profile['email'] ) || empty( $connection_id ) ) {
-		return;
+	if ( ! empty( $profile['email'] ) && ! empty( $connection_id ) ) {
+		$api = new Airstory\API;
+		$api->delete_target( $profile['email'], $connection_id );
 	}
-
-	$api = new Airstory\API;
-	$api->delete_target( $profile['email'], $connection_id );
 
 	// Clean up the user meta.
 	delete_user_option( $user_id, '_airstory_target' );

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -305,6 +305,10 @@ class ConnectionTest extends \Airstory\TestCase {
 	}
 
 	public function testRemoveConnectionOnlyDeletesIfItHasTheUserEmail() {
+		Patchwork\replace( 'Airstory\API::delete_target', function () {
+			$this->fail( 'This should never be called without the user email address' );
+		} );
+
 		M::userFunction( 'Airstory\Settings\get_user_data', array(
 			'args'   => array( 123, 'profile', array() ),
 			'return' => array( 'email' => '' )
@@ -316,13 +320,17 @@ class ConnectionTest extends \Airstory\TestCase {
 		) );
 
 		M::userFunction( 'delete_user_option', array(
-			'times'  => 0,
+			'times'  => 1,
 		) );
 
 		remove_connection( 123 );
 	}
 
 	public function testRemoveConnectionOnlyDeletesIfItHasTheConnectionID() {
+		Patchwork\replace( 'Airstory\API::delete_target', function () {
+			$this->fail( 'This should never be called without the connection ID' );
+		} );
+
 		M::userFunction( 'Airstory\Settings\get_user_data', array(
 			'args'   => array( 123, 'profile', array() ),
 			'return' => array( 'email' => 'test@example.com' ),
@@ -334,7 +342,7 @@ class ConnectionTest extends \Airstory\TestCase {
 		) );
 
 		M::userFunction( 'delete_user_option', array(
-			'times'  => 0,
+			'times'  => 1,
 		) );
 
 		remove_connection( 123 );

--- a/tests/PHPUnit/UninstallTest.php
+++ b/tests/PHPUnit/UninstallTest.php
@@ -10,6 +10,7 @@ namespace Airstory\Uninstall;
 use WP_Mock as M;
 use Mockery;
 use Patchwork;
+use WP_User_Query;
 
 /**
  * @runTestsInSeparateProcesses
@@ -60,6 +61,11 @@ class UninstallTest extends \Airstory\TestCase {
 	}
 
 	public function testDisconnectAllUsers() {
+		global $wpdb;
+
+		$wpdb         = new \stdClass;
+		$wpdb->prefix = 'wp_2_';
+
 		\WP_User_Query::$__results = array( 1, 2, 3 );
 
 		M::userFunction( 'Airstory\Connection\remove_connection', array(
@@ -71,9 +77,19 @@ class UninstallTest extends \Airstory\TestCase {
 
 		$this->bootstrap();
 		disconnect_all_users();
+
+		$this->assertContains( array(
+			'key'     => 'wp_2__airstory_target',
+			'compare' => 'EXISTS',
+		), WP_User_Query::$__query['meta_query'], 'The meta_key should include the database table prefix.' );
 	}
 
 	public function testDisconnectAllUsersChunksUserQueries() {
+		global $wpdb;
+
+		$wpdb         = new \stdClass;
+		$wpdb->prefix = 'wp_';
+
 		\WP_User_Query::$__results = array( 1, 2, 3 );
 
 		M::userFunction( 'Airstory\Connection\remove_connection', array(

--- a/uninstall.php
+++ b/uninstall.php
@@ -12,7 +12,9 @@ namespace Airstory\Uninstall;
 
 use Airstory\Connection as Connection;
 
+require_once __DIR__ . '/includes/class-api.php';
 require_once __DIR__ . '/includes/connection.php';
+require_once __DIR__ . '/includes/credentials.php';
 require_once __DIR__ . '/includes/settings.php';
 
 /**

--- a/uninstall.php
+++ b/uninstall.php
@@ -13,6 +13,7 @@ namespace Airstory\Uninstall;
 use Airstory\Connection as Connection;
 
 require_once __DIR__ . '/includes/connection.php';
+require_once __DIR__ . '/includes/settings.php';
 
 /**
  * Retrieve the IDs of any sites with active Airstory connections.

--- a/uninstall.php
+++ b/uninstall.php
@@ -61,15 +61,19 @@ function get_active_site_ids() {
 
 /**
  * Collect any users that are connected to Airstory and close their connections.
+ *
+ * @global $wpdb
  */
 function disconnect_all_users() {
+	global $wpdb;
+
 	$user_args       = array(
 		'fields'      => 'ID',
 		'number'      => 100,
 		'count_total' => false,
 		'meta_query'  => array(
 			array(
-				'key'     => '_airstory_target',
+				'key'     => $wpdb->prefix . '_airstory_target',
 				'compare' => 'EXISTS',
 			),
 		),


### PR DESCRIPTION
Reworks the uninstallation procedure to avoid infinite loops in scenarios where connection data has been partially removed. Fixes #67.