### PR TITLE
Remove unnecessary files from WordPress.org zip file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
 					domainPath: 'languages/',
 					exclude: [
 						'dist',
+						'includes/lib',
 						'node_modules',
 						'tests',
 						'vendor',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,6 +13,14 @@ module.exports = function(grunt) {
 					'composer.json',
 					'CHANGELOG.md',
 					'LICENSE.md',
+
+					/*
+					 * Exclude files not necessary in the distribution.
+					 *
+					 * @link https://github.com/liquidweb/airstory-wp/issues/69
+					 */
+					'!includes/lib/wp-async-task/*.dist',
+					'!includes/lib/wp-async-task/tests/**',
 				],
 				dest: 'dist/'
 			},


### PR DESCRIPTION
This PR removes PHPUnit-related files from `includes/lib/wp-async-task`, as there's no need to bundle them with the WordPress.org download. WP Async Task's README, license, `composer.json`, and main file are preserved, however. Fixes #69.