### PR TITLE
Implement Access-Control-Allow-Origin headers for the webhook endpoint

### DIFF
--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -73,6 +73,9 @@ function handle_webhook( WP_REST_Request $request ) {
 		);
 	}
 
+	// Ensure that the proper CORS headers are sent.
+	add_filter( 'rest_pre_serve_request', __NAMESPACE__ . '\override_cors_headers' );
+
 	// Establish an API connection, using the Airstory token of the connection owner.
 	$api = new Airstory\API;
 	$api->set_token( $user_token );

--- a/includes/webhook.php
+++ b/includes/webhook.php
@@ -104,3 +104,28 @@ function handle_webhook( WP_REST_Request $request ) {
 		'edit_url' => admin_url( $edit_path ),
 	);
 }
+
+/**
+ * Override the default WP REST API CORS headers for the webhook, only enabling requests from the
+ * Airstory domain(s).
+ *
+ * @param bool $served Whether the request has already been served. This will not be used.
+ * @return bool The (unmodified) $served value.
+ */
+function override_cors_headers( $served ) {
+	/**
+	 * Filter the permitted CORS origins for Airstory webhook requests.
+	 *
+	 * @param array $origins Origins that should be permitted via CORS.
+	 */
+	$origins = apply_filters( 'airstory_webhook_cors_origin', array( 'https://app.airstory.co' ) );
+
+	if ( ! empty( $origins ) ) {
+		header( sprintf(
+			'Access-Control-Allow-Origin: %s',
+			implode( ' ', array_map( 'esc_url', $origins ) )
+		) );
+	}
+
+	return $served;
+}

--- a/tests/PHPUnit/WebhookTest.php
+++ b/tests/PHPUnit/WebhookTest.php
@@ -54,6 +54,8 @@ class WebhookTest extends \Airstory\TestCase {
 			->with( 'document' )
 			->andReturn( $document );
 
+		M::expectFilterAdded( 'rest_pre_serve_request', __NAMESPACE__ . '\override_cors_headers' );
+
 		M::userFunction( 'Airstory\Credentials\get_token', array(
 			'args'   => array( 5 ),
 			'return' => uniqid(),


### PR DESCRIPTION
This PR overrides the default WP REST API <abbr title="Cross-Origin Resource Sharing">CORS</abbr> headers for the Airstory webhook, only permitting requests from https://app.airstory.co.

This is related to, but does not completely take care of, #74.