### PR TITLE
Attempt to resolve the webhook URI before connecting to Airstory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 * Explicitly set `Access-Control-Allow-Origin` headers for the Airstory webhook request ([#74]).
+* Plugin now attempts to resolve any redirects for the webhook URI before connecting to Airstory ([#75]).
 
 
 ## [1.1.4]
@@ -68,3 +69,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [1.0.1]: https://github.com/liquidweb/airstory-wp/releases/tag/v1.0.1
 [1.0.0]: https://github.com/liquidweb/airstory-wp/releases/tag/v1.0.0
 [#74]: https://github.com/liquidweb/airstory-wp/issues/74
+[#75]: https://github.com/liquidweb/airstory-wp/issues/75

--- a/includes/connection.php
+++ b/includes/connection.php
@@ -61,9 +61,18 @@ function get_target( $user_id ) {
 	return array(
 		'identifier' => (string) $user_id, // Airstory expects a string.
 		'name'       => get_bloginfo( 'name' ),
-		'url'        => get_rest_url( null, '/airstory/v1/webhook', 'https' ),
+		'url'        => get_webhook_uri(),
 		'type'       => 'wordpress',
 	);
+}
+
+/**
+ * Retrieve the webhook URL for this site.
+ *
+ * @return string The Airstory webhook endpoint URI.
+ */
+function get_webhook_uri() {
+	return get_rest_url( null, '/airstory/v1/webhook', 'https' );
 }
 
 /**

--- a/includes/connection.php
+++ b/includes/connection.php
@@ -86,6 +86,11 @@ function get_webhook_uri() {
 
 	if ( $resolved ) {
 		$url = $resolved;
+
+		// If the resolved URL is only a path (no host), prepend one.
+		if ( wp_parse_url( $resolved, PHP_URL_PATH ) === $resolved ) {
+			$url = site_url( $resolved );
+		}
 	}
 
 	wp_cache_set( 'airstory_webhook_uri', $url, 'airstory' );

--- a/includes/connection.php
+++ b/includes/connection.php
@@ -61,7 +61,7 @@ function get_target( $user_id ) {
 	return array(
 		'identifier' => (string) $user_id, // Airstory expects a string.
 		'name'       => get_bloginfo( 'name' ),
-		'url'        => get_webhook_uri(),
+		'url'        => esc_url_raw( get_webhook_uri() ),
 		'type'       => 'wordpress',
 	);
 }

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -155,10 +155,43 @@ class ConnectionTest extends \Airstory\TestCase {
 			'return' => $url,
 		) );
 
+		M::userFunction( 'wp_parse_url', array(
+			'returnUsing' => '/airstory/v1/webhook/',
+		) );
+
 		M::userFunction( 'wp_cache_get' );
 		M::userFunction( 'wp_remote_head' );
 		M::userFunction( 'wp_remote_retrieve_header', array(
 			'return' => $url . '/',
+		) );
+
+		M::userFunction( 'wp_cache_set', array(
+			'times' => 1,
+			'args'  => array( 'airstory_webhook_uri', $url . '/', 'airstory' ),
+		) );
+
+		$this->assertEquals( $url . '/', get_webhook_uri() );
+	}
+
+	public function testGetWebhookUriCreatesAbsoluteRedirectUris() {
+		$url = 'http://example.com/airstory/v1/webhook';
+
+		M::userFunction( 'get_rest_url', array(
+			'return' => $url,
+		) );
+
+		M::userFunction( 'wp_parse_url', array(
+			'return' => '/airstory/v1/webhook/',
+		) );
+
+		M::userFunction( 'site_url', array(
+			'return' => $url . '/',
+		) );
+
+		M::userFunction( 'wp_cache_get' );
+		M::userFunction( 'wp_remote_head' );
+		M::userFunction( 'wp_remote_retrieve_header', array(
+			'return' => '/airstory/v1/webhook/',
 		) );
 
 		M::userFunction( 'wp_cache_set', array(

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -109,8 +109,7 @@ class ConnectionTest extends \Airstory\TestCase {
 			'return' => 'Example Blog',
 		) );
 
-		M::userFunction( 'get_rest_url', array(
-			'args'   => array( null, '/airstory/v1/webhook', 'https' ),
+		M::userFunction( __NAMESPACE__ . '\get_webhook_uri', array(
 			'return' => 'http://example.com/airstory/v1/webhook'
 		) );
 
@@ -120,6 +119,15 @@ class ConnectionTest extends \Airstory\TestCase {
 		$this->assertEquals( 'Example Blog', $response['name'] );
 		$this->assertEquals( 'http://example.com/airstory/v1/webhook', $response['url'] );
 		$this->assertEquals( 'wordpress', $response['type'] );
+	}
+
+	public function testGetWebhookUri() {
+		M::userFunction( 'get_rest_url', array(
+			'args'   => array( null, '/airstory/v1/webhook', 'https' ),
+			'return' => 'http://example.com/airstory/v1/webhook'
+		) );
+
+		$this->assertEquals( 'http://example.com/airstory/v1/webhook', get_webhook_uri() );
 	}
 
 	public function testHasConnection() {

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -122,12 +122,63 @@ class ConnectionTest extends \Airstory\TestCase {
 	}
 
 	public function testGetWebhookUri() {
+		$url = 'http://example.com/airstory/v1/webhook';
+
 		M::userFunction( 'get_rest_url', array(
 			'args'   => array( null, '/airstory/v1/webhook', 'https' ),
-			'return' => 'http://example.com/airstory/v1/webhook'
+			'return' => $url,
 		) );
 
-		$this->assertEquals( 'http://example.com/airstory/v1/webhook', get_webhook_uri() );
+		M::userFunction( 'wp_cache_get' );
+
+		M::userFunction( 'wp_remote_head', array(
+			'times' => 1,
+			'args'  => array( $url ),
+		) );
+
+		M::userFunction( 'wp_remote_retrieve_header', array(
+			'return' => '',
+		) );
+
+		M::userFunction( 'wp_cache_set', array(
+			'times' => 1,
+			'args'  => array( 'airstory_webhook_uri', $url, 'airstory' ),
+		) );
+
+		$this->assertEquals( $url, get_webhook_uri() );
+	}
+
+	public function testGetWebhookUriChecksForRedirects() {
+		$url = 'http://example.com/airstory/v1/webhook';
+
+		M::userFunction( 'get_rest_url', array(
+			'return' => $url,
+		) );
+
+		M::userFunction( 'wp_cache_get' );
+		M::userFunction( 'wp_remote_head' );
+		M::userFunction( 'wp_remote_retrieve_header', array(
+			'return' => $url . '/',
+		) );
+
+		M::userFunction( 'wp_cache_set', array(
+			'times' => 1,
+			'args'  => array( 'airstory_webhook_uri', $url . '/', 'airstory' ),
+		) );
+
+		$this->assertEquals( $url . '/', get_webhook_uri() );
+	}
+
+	public function testGetWebhookUriReturnsFromCache() {
+		M::userFunction( 'wp_cache_get', array(
+			'return' => 'http://example.com/foo',
+		) );
+
+		M::userFunction( 'get_rest_url', array(
+			'times' => 0,
+		) );
+
+		$this->assertEquals( 'http://example.com/foo', get_webhook_uri() );
 	}
 
 	public function testHasConnection() {
@@ -402,6 +453,25 @@ class ConnectionTest extends \Airstory\TestCase {
 		) );
 
 		set_connected_blogs( 5, array() );
+	}
+
+	public function testTriggerConnectionRefresh() {
+		M::userFunction( 'wp_cache_delete', array(
+			'times' => 1,
+			'args'  => array( 'airstory_webhook_uri', 'airstory' ),
+		) );
+
+		M::expectAction( 'airstory_update_all_connections' );
+
+		trigger_connection_refresh( 'old', 'new' );
+	}
+
+	public function testTriggerConnectionRefreshOnlyFiresIfValuesChanged() {
+		M::userFunction( 'wp_cache_delete', array(
+			'times' => 0,
+		) );
+
+		trigger_connection_refresh( 'same', 'same' );
 	}
 }
 

--- a/tests/PHPUnit/ConnectionTest.php
+++ b/tests/PHPUnit/ConnectionTest.php
@@ -113,6 +113,8 @@ class ConnectionTest extends \Airstory\TestCase {
 			'return' => 'http://example.com/airstory/v1/webhook'
 		) );
 
+		M::passthruFunction( 'esc_url_raw' );
+
 		$response = get_target( 5 );
 
 		$this->assertEquals( '5', $response['identifier'] );


### PR DESCRIPTION
This PR adds the `Airstory\Connection\get_webhook_uri()` function, which performs additional checks against the WP REST API before connecting to Airstory.

Rather than relying on the (self-reporting) output of `get_rest_url()`, `get_webhook_uri()` will send an HTTP `HEAD` request to that endpoint to see if any redirects are in-play. The resulting URI is then stored in the object cache, to be recalculated only when a significant change (such as a domain change) is made to the site.

This approach should help reduce the number of cases where the Airstory target and effective path ([see this comment in #74 for details](https://github.com/liquidweb/airstory-wp/issues/74#issuecomment-354828045)) do not match.