### PR TITLE
Whitelist the Airstory webhook within WP-SpamShield

### DIFF
--- a/airstory.php
+++ b/airstory.php
@@ -26,6 +26,7 @@ if ( ! defined( 'AIRSTORY_DIR' ) ) {
 require_once AIRSTORY_DIR . '/includes/async-tasks.php';
 require_once AIRSTORY_DIR . '/includes/class-api.php';
 require_once AIRSTORY_DIR . '/includes/connection.php';
+require_once AIRSTORY_DIR . '/includes/compatibility.php';
 require_once AIRSTORY_DIR . '/includes/core.php';
 require_once AIRSTORY_DIR . '/includes/credentials.php';
 require_once AIRSTORY_DIR . '/includes/formatting.php';

--- a/includes/compatibility.php
+++ b/includes/compatibility.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Compatibility with third-party plugins.
+ *
+ * @package Airstory
+ */
+
+namespace Airstory\Compatibility;
+
+/**
+ * Don't let WP-SpamShield block the Airstory webhook.
+ *
+ * By default, WP-SpamShield's Anti-Spam for Miscellaneous Forms feature will block incoming POST
+ * requests that aren't explicitly whitelisted.
+ *
+ * @link https://www.redsandmarketing.com/plugins/wp-spamshield-anti-spam/compatibility-guide/
+ *
+ * @param bool $bypass Whether or not to bypass WP-SpamShield for the request.
+ *
+ * @return bool The possibly-modified $bypass value.
+ */
+function wpspamshield_whitelist_webhook( $bypass ) {
+	if ( untrailingslashit( $_SERVER['REQUEST_URI'] ) === '/' . rest_get_url_prefix() . '/airstory/v1/webhook' ) {
+		$bypass = true;
+	}
+
+	return $bypass;
+}
+add_filter( 'wpss_misc_form_spam_check_bypass', __NAMESPACE__ . '\wpspamshield_whitelist_webhook' );

--- a/tests/PHPUnit/CompatibilityTest.php
+++ b/tests/PHPUnit/CompatibilityTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Tests for the plugin's compatibility layers.
+ *
+ * @package Airstory
+ */
+
+namespace Airstory\Compatibility;
+
+use WP_Mock as M;
+
+class CompatibilityTest extends \Airstory\TestCase {
+
+	protected $testFiles = array(
+		'compatibility.php',
+	);
+
+	public function testWpSpamShieldWhitelistWebhook() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/airstory/v1/webhook';
+
+		M::userFunction( 'rest_get_url_prefix', [
+			'return_in_order' => [ 'wp-json', 'some-other-value' ],
+		] );
+		M::passthruFunction( 'untrailingslashit' );
+
+		$this->assertTrue( wpspamshield_whitelist_webhook( false ) );
+		$this->assertFalse( wpspamshield_whitelist_webhook( false ) );
+	}
+}


### PR DESCRIPTION
For sites running WP-SpamShield, hook into the `wpss_misc_form_spam_check_bypass` filter and, if the request is to the webhook URL, enable WP-SpamShield to be bypassed.

This is based on the official WP-SpamShield plugin compatibility guide: https://www.redsandmarketing.com/plugins/wp-spamshield-anti-spam/compatibility-guide/

Fixes #79.