### PR TITLE
Only require Mcrypt for sites running PHP < 7.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ $ git clone https://github.com/liquidweb/airstory-wp.git airstory && cd airstory
 $ composer install && npm install
 ```
 
-The Airstory plugin is built for PHP versions 5.3 and above (required for using PHP namespaces), and requires the `dom`, `mcrypt`, and `openssl` PHP extensions.
+The Airstory plugin is built for PHP versions 5.3 and above (required for using PHP namespaces), and requires the `dom` and `openssl` PHP extensions. Additionally, `mcrypt` is required for PHP versions below 7.0.
 
 
 ### Project structure

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin enables [Airstory](http://www.airstory.co/) users to connect their W
 
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Sign up for a free two-week trial!](http://www.airstory.co/)
-* PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
+* PHP version 5.3 or higher, with the DOM and OpenSSL extensions active. Additionally, the Mcrypt PHP extension is required for PHP versions below 7.0.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -243,7 +243,14 @@ function check_compatibility() {
 	}
 
 	// Check required PHP extensions.
-	$extensions = array( 'dom', 'mcrypt', 'openssl' );
+	$extensions = array( 'dom', 'openssl' );
+
+	// Mcrypt is required for PHP < 7.0.
+	if ( version_compare( PHP_VERSION, '7.0.0', '<' ) ) {
+		$extensions[] = 'mcrypt';
+	} else {
+		$compatibility['details']['mcrypt'] = true;
+	}
 
 	foreach ( $extensions as $extension ) {
 		$compatibility['details'][ $extension ] = extension_loaded( $extension );

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ Airstory is a paid solution, which includes support and integrations, like this 
 
 * This plugin requires an active [Airstory](http://www.airstory.co/) subscription.
 	* Not already an Airstory user? [Sign up for a free two-week trial!](http://www.airstory.co/)
-* PHP version 5.3 or higher, with the DOM, Mcrypt, and OpenSSL extensions active.
+* PHP version 5.3 or higher, with the DOM and OpenSSL extensions active. Additionally, the Mcrypt PHP extension is required for PHP versions below 7.0.
 * The WordPress site must have a valid SSL certificate in order for Airstory to publish content.
 
 

--- a/tests/PHPUnit/CredentialsTest.php
+++ b/tests/PHPUnit/CredentialsTest.php
@@ -13,8 +13,8 @@ use Mockery;
 use WP_Error;
 
 /**
+ * @requires PHP 7.0
  * @requires extension openssl
- * @requires extension mcrypt
  */
 class CredentialsTest extends \Airstory\TestCase {
 

--- a/tests/PHPUnit/ToolsTest.php
+++ b/tests/PHPUnit/ToolsTest.php
@@ -95,6 +95,10 @@ class ToolsTest extends \Airstory\TestCase {
 	 * @runInSeparateProcess
 	 */
 	public function testCheckCompatibilityWithMcrypt() {
+		M::userFunction( __NAMESPACE__ . '\version_compare', array(
+			'return' => true,
+		) );
+
 		M::userFunction( __NAMESPACE__ . '\extension_loaded', array(
 			'return' => false,
 		) );
@@ -107,6 +111,21 @@ class ToolsTest extends \Airstory\TestCase {
 
 		$this->assertFalse( $compatibility['compatible'] );
 		$this->assertFalse( $compatibility['details']['mcrypt'] );
+	}
+
+	/**
+	 * @requires PHP 7.0
+	 * @runInSeparateProcess
+	 */
+	public function testCheckCompatibilityWithMcryptForPHP7() {
+		M::userFunction( __NAMESPACE__ . '\verify_https_support', array(
+			'return' => true,
+		) );
+
+		$compatibility = check_compatibility();
+
+		$this->assertTrue( $compatibility['compatible'] );
+		$this->assertTrue( $compatibility['details']['mcrypt'] );
 	}
 
 	/**

--- a/tests/PHPUnit/WebhookTest.php
+++ b/tests/PHPUnit/WebhookTest.php
@@ -166,6 +166,10 @@ class WebhookTest extends \Airstory\TestCase {
 		$request->shouldReceive( 'get_param' )->with( 'project' )->andReturn( $project );
 		$request->shouldReceive( 'get_param' )->with( 'document' )->andReturn( $document );
 
+		M::userFunction( 'Airstory\Credentials\get_token', array(
+			'return' => 'token',
+		) );
+
 		M::userFunction( 'Airstory\Core\get_current_draft', array(
 			'return' => 123,
 		) );


### PR DESCRIPTION
The Mcrypt requirement was born out of the need for mcrypt_create_iv(), which serves as the fallback for sites that don't have access to the random_bytes() function (introduced in PHP 7.0).

As such, sites running PHP 7.0 or newer don't need Mcrypt and, the library itself was deprecated in 7.1 and removed in 7.2 (http://php.net/manual/en/intro.mcrypt.php).

Fixes #81.