### PR TITLE
Log libxml errors

### DIFF
--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -330,3 +330,34 @@ function retrieve_original_media( $url, $post_id, $metadata ) {
 	sideload_single_image( $original_media_url, $post_id, $metadata );
 }
 add_action( 'airstory_sideload_single_image', __NAMESPACE__ . '\retrieve_original_media', 10, 3 );
+
+/**
+ * A helper function to format libXMLError messages for logging.
+ *
+ * @param libXMLError $error The libXMLError error object.
+ *
+ * @return string A nicely-formatted error message.
+ */
+function format_libxml_error( $error ) {
+	if ( ! $error instanceof \libXMLError ) {
+		return '';
+	}
+
+	// Map the possible LIBXML_ERR_* constants to labels.
+	$levels = [
+		LIBXML_ERR_WARNING => 'Warning',
+		LIBXML_ERR_ERROR   => 'Error',
+		LIBXML_ERR_FATAL   => 'Fatal',
+	];
+
+	return sprintf(
+		'[LibXML %1$s] There was a problem parsing the document: "%2$s".'
+		. PHP_EOL . '- %3$s line %4$d, column %5$d. XML error code %6$d.',
+		isset( $levels[ $error->level ] ) ? $levels[ $error->level ] : $levels[ LIBXML_ERR_ERROR ],
+		$error->message,
+		$error->file,
+		$error->line,
+		$error->column,
+		$error->code
+	);
+}

--- a/includes/formatting.php
+++ b/includes/formatting.php
@@ -34,7 +34,13 @@ function get_body_contents( $content ) {
 	$body = $doc->saveHTML( $body_node->item( 0 ) );
 
 	// If an error occurred while parsing the data, return an empty string.
-	if ( libxml_get_errors() ) {
+	$errors = libxml_get_errors();
+
+	if ( ! empty( $errors ) ) {
+		foreach ( $errors as $error ) {
+			// @codingStandardsIgnoreLine
+			trigger_error( format_libxml_error( esc_html( $error ) ), E_USER_WARNING );
+		}
 		$body = '';
 	}
 

--- a/tests/PHPUnit/FormattingTest.php
+++ b/tests/PHPUnit/FormattingTest.php
@@ -118,6 +118,24 @@ EOT;
 		$this->assertEmpty( get_body_contents( $response ) );
 	}
 
+	/**
+	 * @runInSeparateProcess Or risk the libxml error buffer getting all kinds of screwy.
+	 */
+	public function testGetBodyContentsWithInvalidHTMLBody() {
+		$response = <<<EOT
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<title></title>
+<body>
+	<h1>Bad heading</div>
+</body>
+</html>
+EOT;
+
+		$this->expectException('PHPUnit_Framework_Error_Warning');
+		$this->assertEmpty( get_body_contents( $response ) );
+	}
+
 	public function testGetBodyContentsDoesNotButcherEmoji() {
 		$emoji = '<p>emoji: 😉</p>';
 

--- a/tests/PHPUnit/FormattingTest.php
+++ b/tests/PHPUnit/FormattingTest.php
@@ -678,4 +678,24 @@ EOT;
 
 		retrieve_original_media( $url, 1, array() );
 	}
+
+	public function testFormatLibXMLError() {
+		$error = new \libXMLError();
+		$error->level   = LIBXML_ERR_ERROR;
+		$error->code    = 76; // XML_ERR_TAG_NAME_MISMATCH.
+		$error->column  = 23;
+		$error->message = 'Unexpected end tag : div';
+		$error->file    = 'some-file.html';
+		$error->line    = 5;
+
+		$this->assertEquals(
+			'[LibXML Error] There was a problem parsing the document: "Unexpected end tag : div".'
+			. PHP_EOL . '- some-file.html line 5, column 23. XML error code 76.',
+			format_libxml_error( $error )
+		);
+	}
+
+	public function testFormatLibXMLErrorWithInvalidError() {
+		$this->assertEmpty( format_libxml_error( array() ) );
+	}
 }


### PR DESCRIPTION
There have been a number of issues reported (both on WordPress.org and here, see #80) where posts are created and the titles populated, but with empty post bodies which is (obviously) not helpful.

As it turns out, this is very likely due to `Airstory\Formatting\get_body_contents()`, which would call `libxml_use_internal_errors()`, detect if any errors occurred while parsing the document body, then return an empty body if parsing errors occurred.

Ideally, the Airstory app wouldn't be returning invalid HTML (I'll reach out to @stevendluke separately), but this PR adds logging so we can determine exactly _why_ a post body comes back as empty.