### PR TITLE
Prepare the plugin to be sunset

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Code Climate](https://codeclimate.com/github/liquidweb/airstory-wp/badges/gpa.svg)](https://codeclimate.com/github/liquidweb/airstory-wp)
 [![Test Coverage](https://codeclimate.com/github/liquidweb/airstory-wp/badges/coverage.svg)](https://codeclimate.com/github/liquidweb/airstory-wp/coverage)
 
+> **Notice:** [Airstory documents are being deprecated on January 15, 2019](https://www.airstory.co/airstory-update-2018/), at which point this plugin will cease to connect.
+
 This plugin enables [Airstory](http://www.airstory.co/) users to connect their WordPress sites, enabling authors to leverage the exceptional editorial experience of Airstory with the powerful publishing of WordPress.
 
 ## Requirements

--- a/airstory.php
+++ b/airstory.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Airstory
  * Plugin URI:  http://www.airstory.co/integrations/
- * Description: Send your blog posts from Airstory writing software to WordPress for publication.
+ * Description: *DEPRECATED* Send your blog posts from Airstory writing software to WordPress for publication.
  * Version:     1.1.6
  * Author:      Liquid Web
  * Author URI:  https://www.liquidweb.com

--- a/airstory.php
+++ b/airstory.php
@@ -33,3 +33,4 @@ require_once AIRSTORY_DIR . '/includes/formatting.php';
 require_once AIRSTORY_DIR . '/includes/settings.php';
 require_once AIRSTORY_DIR . '/includes/tools.php';
 require_once AIRSTORY_DIR . '/includes/webhook.php';
+require_once AIRSTORY_DIR . '/includes/sunset.php';

--- a/assets/js/sunset.js
+++ b/assets/js/sunset.js
@@ -1,0 +1,19 @@
+/**
+ * Scripting for the sunset notice.
+ *
+ * @package Airstory
+ * @author  Liquid Web
+ */
+/* global ajaxurl */
+
+( function ($) {
+	'use strict';
+
+	$(document.getElementById('airstory-sunset-notice'))
+		.on('click', '.notice-dismiss', function () {
+			$.post(ajaxurl, {
+				action: 'airstory-dismiss-sunset-notice'
+			});
+		});
+
+} )(jQuery);

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -101,6 +101,7 @@ function render_profile_settings( $user ) {
 ?>
 
 	<h2 id="airstory"><?php esc_html_e( 'Airstory Configuration', 'airstory' ); ?></h2>
+	<?php do_action( 'airstory_before_settings', $user ); ?>
 	<table class="form-table">
 		<tbody>
 			<tr>

--- a/includes/sunset.php
+++ b/includes/sunset.php
@@ -13,6 +13,9 @@
 
 namespace Airstory\Sunset;
 
+use Airstory\Connection as Connection;
+use Airstory\Settings as Settings;
+
 define( __NAMESPACE__ . '\DEPRECATION_NOTICE', 'https://www.airstory.co/airstory-update-2018/' );
 
 /**
@@ -36,3 +39,66 @@ function plugin_screen_deprecation_link( $links, $plugin ) {
 	return $links;
 }
 add_filter( 'plugin_row_meta', __NAMESPACE__ . '\plugin_screen_deprecation_link', 10, 2 );
+
+/**
+ * Show site admins and/or connected users a notice about the deprecation.
+ */
+function render_sunset_notice() {
+	$user_id = wp_get_current_user()->ID;
+
+	// Don't show this message if the user has already dismissed it.
+	if ( Settings\get_user_data( $user_id, 'sunset_notice_dismissed', false ) ) {
+		return;
+	}
+
+	if ( current_user_can( 'activate_plugins' ) ) {
+		$message = __( 'On this date, users will no longer be able to import posts from Airstory. Please plan on deactivating/removing the Airstory plugin ahead of this date.', 'airstory' );
+	} elseif ( Connection\has_connection( $user_id ) ) {
+		$message = __( 'On this date, you will no longer be able to import posts from Airstory. Please import any posts you wish to save into WordPress (or otherwise export from Airstory) ahead of this date.', 'airstory' );
+	} else {
+		// No connection or power to change things, so there's no message.
+		return;
+	}
+
+	// Ensure the necessary script is loaded.
+	wp_enqueue_script( 'airstory-sunset' );
+
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent
+?>
+
+	<div id="airstory-sunset-notice" class="notice notice-warning is-dismissible">
+		<p><strong><?php esc_html_e( 'Airstory documents are being deprecated on January 15, 2019!', 'airstory' ); ?></strong></p>
+		<p><?php echo esc_html( $message ); ?></p>
+		<p><a href="<?php echo esc_url( DEPRECATION_NOTICE ); ?>"><?php esc_html_e( 'Additional information is available on the Airstory site.', 'airstory' ); ?></a></p>
+		<button type="button" class="notice-dismiss">
+			<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice', 'airstory' ); ?></span>
+		</button>
+	</div>
+
+<?php
+	// phpcs:enable Generic.WhiteSpace.ScopeIndent
+}
+add_action( 'admin_notices', __NAMESPACE__ . '\render_sunset_notice' );
+add_action( 'network_admin_notices', __NAMESPACE__ . '\render_sunset_notice' );
+
+/**
+ * Enqueue the Airstory sunset notice scripting.
+ */
+function register_script() {
+	wp_register_script(
+		'airstory-sunset',
+		plugins_url( 'assets/js/sunset.js', __DIR__ ),
+		array( 'jquery' ),
+		AIRSTORY_VERSION,
+		true
+	);
+}
+add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\register_script' );
+
+/**
+ * Dismiss the sunset notice.
+ */
+function dismiss_notice() {
+	Settings\set_user_data( wp_get_current_user()->ID, 'sunset_notice_dismissed', true );
+}
+add_action( 'wp_ajax_airstory-dismiss-sunset-notice', __NAMESPACE__ . '\dismiss_notice' );

--- a/includes/sunset.php
+++ b/includes/sunset.php
@@ -102,3 +102,20 @@ function dismiss_notice() {
 	Settings\set_user_data( wp_get_current_user()->ID, 'sunset_notice_dismissed', true );
 }
 add_action( 'wp_ajax_airstory-dismiss-sunset-notice', __NAMESPACE__ . '\dismiss_notice' );
+
+/**
+ * Display a notice above the user settings.
+ */
+function render_settings_page_sunset_notice() {
+	// phpcs:disable Generic.WhiteSpace.ScopeIndent
+?>
+
+	<div class="notice notice-warning inline">
+		<p><?php echo wp_kses_post( __( '<strong>Reminder:</strong> Airstory documents are being deprecated on January 15, 2019. Please export all content from Airstory by this date!', 'airstory' ) ); ?></p>
+		<p><a href="<?php echo esc_url( DEPRECATION_NOTICE ); ?>"><?php esc_html_e( 'Additional information is available on the Airstory site.', 'airstory' ); ?></a></p>
+	</div>
+
+<?php
+	// phpcs:enable Generic.WhiteSpace.ScopeIndent
+}
+add_action( 'airstory_before_settings', __NAMESPACE__ . '\render_settings_page_sunset_notice' );

--- a/includes/sunset.php
+++ b/includes/sunset.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Credentials storage for Airstory API keys.
+ *
+ * At the time of this writing, Airstory exposes bearer tokens directly via the "My Account" panel
+ * when logged into the app. Since it would be silly to simply store these tokens — despite the API
+ * being largely read-only — in the database, this approach leverages the OpenSSL library.
+ *
+ * @link http://php.net/manual/en/intro.openssl.php
+ *
+ * @package Airstory
+ */
+
+namespace Airstory\Sunset;
+
+define( __NAMESPACE__ . '\DEPRECATION_NOTICE', 'https://www.airstory.co/airstory-update-2018/' );
+
+/**
+ * Add a deprecation notice to the plugin screen.
+ *
+ * @param array  $links  Plugin meta links.
+ * @param string $plugin The plugin filename.
+ *
+ * @return array The filtered $links array.
+ */
+function plugin_screen_deprecation_link( $links, $plugin ) {
+	if ( 'airstory.php' === basename( $plugin ) ) {
+		$links[] = sprintf(
+			/* Translators: %1$s is the URL to the deprecation notice, %2$s is the anchor. */
+			'<a href="%1$s"><strong>%2$s</strong></a>',
+			esc_url( DEPRECATION_NOTICE ),
+			esc_html__( 'Deprecation Notice', 'airstory' )
+		);
+	}
+
+	return $links;
+}
+add_filter( 'plugin_row_meta', __NAMESPACE__ . '\plugin_screen_deprecation_link', 10, 2 );

--- a/readme.txt
+++ b/readme.txt
@@ -14,6 +14,8 @@ Send your blog posts from Airstory writing software to WordPress for publication
 
 == Description ==
 
+**Notice:** [Airstory documents are being deprecated on January 15, 2019](https://www.airstory.co/airstory-update-2018/), at which point this plugin will cease to connect.
+
 Send your blog posts from [Airstory](http://www.airstory.co/) to WordPress.
 
 === Publish Better Content ===


### PR DESCRIPTION
This PR adds several notices throughout the plugin, ensuring that users are well-aware that [Airstory is deprecating its documents feature on January 15, 2019](https://www.airstory.co/airstory-update-2018/).

Users are alerted in a few ways:

1. Users that are either admins or have connections will be shown a dismissible message within WP Admin (once it's dismissed, it won't be shown to that user again)
2. "Deprecated" added to the plugin description on the plugins page, along with a link to the deprecation notice
3. A non-dismissible, inline notice on the user settings screen.

Without knowledge of what will happen to the Airstory API, there isn't much we can do to deprecate that gracefully beyond the "if we get a bad response, provide a `WP_Error` and fail gracefully" logic we already have in place.

Fixes #90.